### PR TITLE
Fix `0` and `''` not being recognized properly by the type checker

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,5 +31,8 @@
     "todomvc-common": "^1.0.1",
     "webpack": "^1.5.3",
     "webpack-dev-server": "^1.7.0"
+  },
+  "dependencies": {
+    "type-detect": "^1.0.0"
   }
 }

--- a/src/types.js
+++ b/src/types.js
@@ -1,29 +1,24 @@
+var typeDetect = require('type-detect');
+
+
+var typeToTypeDetect = {}
+typeToTypeDetect[String] = 'string'
+typeToTypeDetect[Number] = 'number'
+typeToTypeDetect[Array] = 'array'
+typeToTypeDetect[Object] = 'object'
+typeToTypeDetect[Boolean] = 'boolean'
+
+
 module.exports = function (type, value) {
 
-  if (type === String && typeof value !== 'string') {
-    return false;
+  if (typeToTypeDetect.hasOwnProperty(type)) {
+    return typeDetect(value) === typeToTypeDetect[type]
+  }
+  if (typeDetect(type) === 'function') {
+    return type(value)
   }
 
-  if (type === Number && typeof value !== 'number') {
-    return false;
-  }
-
-  if (type === Array && !Array.isArray(value)) {
-    return false;
-  }
-
-  if (type === Object && !(typeof value === 'object' && !Array.isArray(value) && value !== null)) {
-    return false;
-  }
-
-  if (type === Boolean && typeof value !== 'boolean') {
-    return false;
-  }
-
-  if (typeof type === 'function') {
-    return type(value);
-  }
-
+  // Right now we return `true` if the type passed in was not one we knew
+  // about and not a function.
   return true;
-
 };

--- a/tests/types.js
+++ b/tests/types.js
@@ -64,6 +64,7 @@ exports['should validate outputs'] = function (test) {
 
 exports['should validate String'] = function (test) {
   test.ok(types(String, '123'));
+  test.ok(types(String, '')); // issue #49
   test.ok(!types(String, 123));
   test.ok(!types(String, true));
   test.ok(!types(String, {}));
@@ -74,6 +75,7 @@ exports['should validate String'] = function (test) {
 exports['should validate Number'] = function (test) {
   test.ok(!types(Number, '123'));
   test.ok(types(Number, 123));
+  test.ok(types(Number, 0)); // issue #49
   test.ok(!types(Number, true));
   test.ok(!types(Number, {}));
   test.ok(!types(Number, []));


### PR DESCRIPTION
This will close #49.

I was having trouble getting it to pick up `0` and `""` as the right types, so I move to using the [type-detect](https://github.com/chaijs/type-detect)t library for all type checking.

If this is accepted, it might make sense to change type checking to use the string that the `type-detect` library uses, instead of passing in the base type things. That we we get a bunch of types for free, like `date`. Of course we still want support for custom functions.