### PR TITLE
Add note about state parameter being read-only in async actions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,10 @@ function MyAction (input, state, output) {
 
 export default MyAction;
 ```
+*Note*: Asynchronous actions *cannot* mutate state. Calling `set` or `merge` on the `state` parameter above will throw an error, as they will be undefined.
+
+It is best practice not to mutate state in async actions.
+
 #### Chain
 *actions/setLoading.js*
 ```js


### PR DESCRIPTION
I didn't catch that async actions should not mutate state. Added a warning in the README in case others are confused as well.